### PR TITLE
fix: Corrige typo em userable

### DIFF
--- a/app/models/concerns/userable.rb
+++ b/app/models/concerns/userable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Userable
+module Userable
   extend ActiveSupport::Concern
 
   included do


### PR DESCRIPTION
Sempre utilizar `module` ao invés de `class` nos concerns!