### PR TITLE
feat: Página para realizar criação da conta de um vendedor

### DIFF
--- a/app/controllers/sellers/registrations_controller.rb
+++ b/app/controllers/sellers/registrations_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class Sellers::RegistrationsController < Devise::RegistrationsController
+  before_action :redirect_when_already_signed_in, only: %i[new create]
+
+  # GET /sellers/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /sellers
+  def create
+    super
+    if resource.persisted?
+      Current.seller = resource
+      User.create!(create_user_params)
+
+      flash[:notice] = t("sellers.registrations.signed_up", full_name: resource.full_name)
+    else
+      flash[:alert] = t("sellers.registrations.signed_up_failed")
+    end
+  end
+
+  # GET /sellers/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /sellers
+  # def update
+  #   super
+  # end
+
+  # DELETE /sellers
+  # def destroy
+  #   super
+  # end
+
+  private
+  def create_user_params
+    params.require(:seller).permit(:first_name, :last_name, :phone_number).merge(userable: Current.seller)
+  end
+
+  def redirect_when_already_signed_in
+    redirect_to request.referrer, alert: t("sellers.already_signed_in") if seller_signed_in?
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :seller
+end

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -5,4 +5,12 @@ class Seller < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :email, presence: true, uniqueness: true
+  validates :document, presence: true, uniqueness: true
+  validates :password, presence: true, length: { minimum: 8 }, format: { with: /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#\$%\^&\*])/ }
+  delegate :first_name, :last_name, :phone_number, to: :user, allow_nil: true
+
+  def full_name
+    "#{first_name} #{last_name}"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,11 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <main class="container mx-auto mt-28 px-5 flex">
+  <body class="bg-slate-100 dark:bg-slate-800 text-gray-900 dark:text-gray-50">
+    <main class="m-auto">
+      <p class="notice"><%= notice %></p>
+      <p class="alert"><%= alert %></p>
+
       <%= yield %>
     </main>
   </body>

--- a/app/views/sellers/registrations/new.html.erb
+++ b/app/views/sellers/registrations/new.html.erb
@@ -1,0 +1,51 @@
+<div class="w-screen h-screen flex flex-col items-center justify-center">
+
+  <div class="flex flex-col items-center gap-6">
+    <h2 class="text-2xl font-semibold">Crie sua conta na YuMenu</h2>
+
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {
+        class: "bg-white dark:bg-slate-600 shadow rounded-md p-6 flex flex-col items-start gap-4"
+      }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="inline-flex gap-2 w-full">
+        <div class="flex flex-col items-start gap-1">
+          <%= f.label "Seu primeiro nome", class: "text-base font-medium", for: "first_name" %>
+          <%= f.text_field :first_name, autofocus: true, autocomplete: "first_name", class: "bg-gray-50 border border-gray-300 text-sm rounded-lg focus:ring-yellow-500 focus:border-yellow-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-yellow-500 dark:focus:border-yellow-500" %>
+        </div>
+        <div class="flex flex-col item-start gap-1">
+          <%= f.label "Seu último nome", class: "text-base font-medium", for: "last_name" %>
+          <%= f.text_field :last_name, autofocus: true, autocomplete: "last_name", class: "bg-gray-50 border border-gray-300 text-sm rounded-lg focus:ring-yellow-500 focus:border-yellow-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-yellow-500 dark:focus:border-yellow-500" %>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1 w-full">
+        <%= f.label "Seu melhor telefone", class: "text-base font-medium", for: "phone" %>
+        <%= f.phone_field :phone_number, autofocus: true, autocomplete: "phone", class: "bg-gray-50 border border-gray-300 text-sm rounded-lg focus:ring-yellow-500 focus:border-yellow-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-yellow-500 dark:focus:border-yellow-500" %>
+
+      </div>
+
+      <div class="flex flex-col gap-1 w-full">
+        <%= f.label "Seu melhor email", class: "text-base font-medium", for: "email" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gray-50 border border-gray-300 text-sm rounded-lg focus:ring-yellow-500 focus:border-yellow-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-yellow-500 dark:focus:border-yellow-500" %>
+      </div>
+
+      <div class="flex flex-col gap-1 w-full">
+        <div>
+          <%= f.label :password, class: "text-base font-medium" %>
+          <% if @minimum_password_length %>
+          <em>(mínimo de <%= @minimum_password_length %> caracteres)</em>
+          <% end %>
+        </div>
+        <%= f.password_field :password, autocomplete: "new-password", class: "bg-gray-50 border border-gray-300 text-sm rounded-lg focus:ring-yellow-500 focus:border-yellow-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-yellow-500 dark:focus:border-yellow-500" %>
+      </div>
+
+      <div class="flex flex-col gap-1 w-full">
+        <%= f.label :password_confirmation, class: "text-base font-medium" %>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "bg-gray-50 border border-gray-300 text-sm rounded-lg focus:ring-yellow-500 focus:border-yellow-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-yellow-500 dark:focus:border-yellow-500" %>
+      </div>
+
+      <%= f.submit "Criar conta", class: "bg-yellow-500 text-white font-semibold rounded-lg p-2.5 w-full mt-4 cursor-pointer" %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/sellers/en.yml
+++ b/config/locales/sellers/en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
+
+en:
+  sellers:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully.blablabla"
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/sellers/pt-BR.yml
+++ b/config/locales/sellers/pt-BR.yml
@@ -1,0 +1,82 @@
+pt-BR:
+  activerecord:
+    models:
+      seller: "Vendedor"
+    attributes:
+      seller:
+        first_name: "Primeiro Nome"
+        last_name: "Último Nome"
+        email: "Email"
+        password: "Senha"
+        password_confirmation: "Confirmação de Senha"
+        current_password: "Senha Atual"
+        created_at: "Criado em"
+        updated_at: "Atualizado em"
+    errors:
+      models:
+        seller:
+          attributes:
+            password:
+              confirmation: "não confere com a senha"
+              empty: "não pode ficar em branco"
+              invalid: "é inválida"
+              too_short: "é muito curta (mínimo de %{count} caracteres)"
+              too_long: "é muito longa (máximo de %{count} caracteres)"
+              blank: "não pode ficar em branco"
+            email:
+              blank: "não pode ficar em branco"
+              invalid: "não é válido"
+              taken: "já está em uso"
+
+  sellers:
+    registrations:
+      signed_up: "Bem-vindo, %{full_name}! Você se cadastrou com sucesso."
+      signed_up_but_unconfirmed: "Um email foi enviado para sua caixa de entrada com um link de confirmação. Por favor, clique no link para ativar sua conta."
+      signed_up_but_inactive: "Você se cadastrou com sucesso. No entanto, não podemos realizar o seu login porque sua conta ainda não foi ativada."
+      signed_up_but_locked: "Você se cadastrou com sucesso. No entanto, não podemos realizar o seu login você porque sua conta está bloqueada."
+      updated: "Sua conta foi atualizada com sucesso."
+      update_needs_confirmation: "Você atualizou sua conta com sucesso, mas precisamos verificar seu novo endereço de email. Por favor, verifique seu email e siga o link de confirmação para confirmar seu novo endereço de email."
+      destroyed: "Tchau! Sua conta foi cancelada com sucesso. Esperamos vê-lo novamente em breve."
+      signed_up_failed: "Houve um problema ao criar sua conta. Por favor, tente novamente."
+    sessions:
+      signed_in: "Login efetuado com sucesso. Seja bem-vindo de volta!"
+      signed_out: "Logout efetuado com sucesso. Até logo!"
+      already_signed_out: "Você não está logado."
+    passwords:
+      send_instructions: "Você receberá um email com instruções sobre como redefinir sua senha em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de email existir em nosso banco de dados, você receberá um link para redefinir sua senha em alguns minutos."
+      updated: "Sua senha foi alterada com sucesso. Você está realizamos o seu login automaticamente."
+      updated_not_active: "Sua senha foi alterada com sucesso."
+      no_token: "Você não pode acessar esta página sem vir de um email de redefinição de senha. Se você veio de um email de redefinição de senha, certifique-se de usar a URL completa fornecida."
+    confirmations:
+      confirmed: "Seu endereço de email foi confirmado com sucesso."
+      send_instructions: "Você receberá um email com instruções sobre como confirmar seu endereço de email em alguns minutos."
+      send_paranoid_instructions: "Se seu endereço de email existir em nosso banco de dados, você receberá um email com instruções sobre como confirmar seu endereço de email em alguns minutos."
+    unlocks:
+      send_instructions: "Você receberá um email com instruções sobre como desbloquear sua conta em alguns minutos."
+      send_paranoid_instructions: "Se sua conta existir, você receberá um email com instruções sobre como desbloqueá-la em alguns minutos."
+      unlocked: "Sua conta foi desbloqueada com sucesso. Por favor, faça login para continuar."
+    failure:
+      unauthenticated: "Você precisa fazer login ou se cadastrar antes de continuar."
+      unconfirmed: "Você precisa confirmar seu endereço de email antes de continuar."
+      locked: "Sua conta está bloqueada."
+      invalid: "Email ou senha inválidos."
+      invalid_token: "Token inválido."
+      timeout: "Sua sessão expirou. Por favor, faça login novamente para continuar."
+      inactive: "Sua conta ainda não foi ativada."
+      already_authenticated: "Você já realizou o login."
+      last_attempt: "Você tem mais uma tentativa antes de sua conta ser bloqueada."
+      not_found_in_database: "Email ou senha inválidos."
+  errors:
+    messages:
+      already_confirmed: "já foi confirmado, por favor, tente fazer login."
+      confirmation_period_expired: "precisa ser confirmado dentro de %{period}, por favor, solicite um novo."
+      expired: "expirou, por favor, solicite um novo."
+      not_found: "não encontrado."
+      not_locked: "não está bloqueado."
+      not_saved:
+        one: "Não foi possível salvar por um erro."
+        other: "Não foi possível salvar por um ou mais erros."
+
+  
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :sellers
+  devise_for :sellers, controllers: {
+    registrations: "sellers/registrations"
+  }
 
   root to: "home#index"
 end


### PR DESCRIPTION
Este PR adiciona o controlador personalizado responsável pela criação de um vendedor (Seller), também foi adicionado regras de validação no model Seller, e junto o aumento da quantidade minima de caracteres em uma senha, alterando o tamanho de 6 para 8.
Também foi adicionado o uso do `Current` como model, irei adotar este padrão, pois quero centralizar todos os current's em um local só, por exemplo, `Current.seller`, `Current.store`, etc.