### PR TITLE
feat: Adiciona a utilização da gem debug para todas as plataformas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ gem 'bootsnap', require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'debug', platforms: %i[mri windows]
+  gem 'debug'
 
   gem 'rspec-core', '~> 3.13'
   gem 'rspec-expectations', '~> 3.13'

--- a/bin/dev
+++ b/bin/dev
@@ -1,16 +1,27 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
+# add `--debug` to the command to enable debugging
+if [ "$1" = "--debug" ]; then
+  if ! gem list debug -i --silent; then
+    echo "Installing debug..."
+    gem install debug
+  fi
+
+  echo "Starting debug mode..."
+  exec rdbg -A
+else
+  if ! gem list foreman -i --silent; then
+    echo "Installing foreman..."
+    gem install foreman
+  fi
+  echo "Starting server..."
+  # Default to port 3000 if not specified
+  export PORT="${PORT:-3000}"
+
+  # Let the debug gem allow remote connections,
+  # but avoid loading until `debugger` is called
+  export RUBY_DEBUG_OPEN="true"
+  export RUBY_DEBUG_LAZY="true"
+
+  exec foreman start -f Procfile.dev "$@"
 fi
-
-# Default to port 3000 if not specified
-export PORT="${PORT:-3000}"
-
-# Let the debug gem allow remote connections,
-# but avoid loading until `debugger` is called
-export RUBY_DEBUG_OPEN="true"
-export RUBY_DEBUG_LAZY="true"
-
-exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
Este PR libera a utilização da gem `debug` para todas as plataformas, e também adiciona a possibilidade de abrir o modo de debugger utilizando o comando `bin/dev --debug` no terminal

```sh
bin/dev --debug