### PR TITLE
fix: Volta a utilizar a porta padrão da conexão com o banco de dados

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   username: yu_monolith
   password: pass_yu_monolith
   host: localhost
-  port: 5433
+  port: 5432
 
 development:
   <<: *default


### PR DESCRIPTION
Agora com uma melhor configuração do meu ambiente local, consegui utilizar a porta padrão de conexão com DB sem atrapalhar meus outros projetos.