### PR TITLE
feat: Adiciona o model Store

### DIFF
--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -3,6 +3,8 @@
 class Seller < ApplicationRecord
   include Userable
 
+  has_one :store, dependent: :destroy, inverse_of: :seller, foreign_key: :user_id
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :email, presence: true, uniqueness: true, format: { with: REGEXP::EMAIL }

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -2,6 +2,8 @@
 
 class Store < ApplicationRecord
   validates :status, presence: true
+  validates :phone_number, format: { with: REGEXP::BRAZIL::PHONE_NUMBER }, allow_blank: true
+  validates :email, format: { with: REGEXP::EMAIL }, allow_blank: true
 
   belongs_to :seller, foreign_key: :user_id, inverse_of: :store
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Store < ApplicationRecord
-  validates :status, presence: true
+  validates :status, presence: true, inclusion: { in: STORE::STATUS }
   validates :phone_number, format: { with: REGEXP::BRAZIL::PHONE_NUMBER }, allow_blank: true
   validates :email, format: { with: REGEXP::EMAIL }, allow_blank: true
 

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Store < ApplicationRecord
+  validates :status, presence: true
+
+  belongs_to :seller, foreign_key: :user_id, inverse_of: :store
+end

--- a/config/initializers/contants.rb
+++ b/config/initializers/contants.rb
@@ -23,3 +23,7 @@ module REGEXP
     end
   end
 end
+
+module STORE
+  STATUS = %w[active inactive].freeze
+end

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,2 +1,10 @@
 pt-BR:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "Falha ao salvar o registro: %{errors}"
+        required: "não pode ficar em branco"
+  errors:
+    messages:
+      required: "não pode ficar em branco"
   

--- a/config/locales/sellers/pt-BR.yml
+++ b/config/locales/sellers/pt-BR.yml
@@ -4,6 +4,7 @@ pt-BR:
       seller: "Vendedor"
     attributes:
       seller:
+        required: "não pode ficar em branco"
         document: "CPF/CNPJ"
         email: "Email"
         password: "Senha"

--- a/config/locales/store/pt-BR.yml
+++ b/config/locales/store/pt-BR.yml
@@ -1,0 +1,34 @@
+pt-BR:
+  activerecord:
+    models:
+      store: "Loja"
+    attributes:
+      store:
+        name: "Nome"
+        status: "Status"
+        favicon_data: "Favicon"
+        logo_data: "Logo"
+        banner_data: "Banner"
+        instagram_url: "Instagram"
+        facebook_url: "Facebook"
+        tiktok_url: "TikTok"
+        email: "E-mail"
+        phone_number: "Número de Telefone"
+        seo_title: "Título SEO"
+        meta_description: "Descrição Meta"
+        meta_keywords: "Palavras-chave Meta"
+    errors:
+      models:
+        store:
+          attributes:
+            status:
+              blank: "não pode ficar em branco"
+              inclusion: "não está incluído na lista"
+            email:
+              blank: "não pode ficar em branco"
+              invalid: "não é válido"
+            phone_number:
+              blank: "não pode ficar em branco"
+              invalid: "não é válido"
+            
+

--- a/db/migrate/20240516005918_create_stores.rb
+++ b/db/migrate/20240516005918_create_stores.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateStores < ActiveRecord::Migration[7.1]
+  def change # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    create_table :stores do |t|
+      t.string :name
+      t.string :status, null: false, default: 'inactive'
+      t.jsonb :favicon_data
+      t.jsonb :logo_data
+      t.jsonb :banner_data
+      t.string :instagram_slug
+      t.string :facebook_slug
+      t.string :tiktok_slug
+      t.string :email
+      t.string :phone_number
+      t.string :seo_title
+      t.text :meta_keywords
+      t.text :meta_description
+
+      t.integer :user_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :stores, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,35 +10,56 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_430_233_218) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_16_005918) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'buyers', force: :cascade do |t|
-    t.string 'document', null: false
+  create_table "buyers", force: :cascade do |t|
+    t.string "document", null: false
   end
 
-  create_table 'sellers', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'document', null: false
-    t.index ['email'], name: 'index_sellers_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_sellers_on_reset_password_token', unique: true
+  create_table "sellers", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "document", null: false
+    t.index ["email"], name: "index_sellers_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_sellers_on_reset_password_token", unique: true
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'first_name', null: false
-    t.string 'last_name', null: false
-    t.string 'phone_number', null: false
-    t.string 'userable_type', null: false
-    t.integer 'userable_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[userable_type userable_id], name: 'index_users_on_userable_type_and_userable_id', unique: true
+  create_table "stores", force: :cascade do |t|
+    t.string "name"
+    t.string "status", default: "inactive", null: false
+    t.jsonb "favicon_data"
+    t.jsonb "logo_data"
+    t.jsonb "banner_data"
+    t.string "instagram_slug"
+    t.string "facebook_slug"
+    t.string "tiktok_slug"
+    t.string "email"
+    t.string "phone_number"
+    t.string "seo_title"
+    t.text "meta_keywords"
+    t.text "meta_description"
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_stores_on_user_id"
   end
+
+  create_table "users", force: :cascade do |t|
+    t.string "first_name", null: false
+    t.string "last_name", null: false
+    t.string "phone_number", null: false
+    t.string "userable_type", null: false
+    t.integer "userable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["userable_type", "userable_id"], name: "index_users_on_userable_type_and_userable_id", unique: true
+  end
+
 end

--- a/spec/factories/sellers.rb
+++ b/spec/factories/sellers.rb
@@ -2,5 +2,8 @@
 
 FactoryBot.define do
   factory :seller do
+    email { 'seller@test.com' }
+    password { 'Ab@341234' }
+    document { '000.000.000-00' }
   end
 end

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :store do
+    name { 'my store' }
+    email { 'teste@store.com' }
+    phone_number { '(11) 94002-8922' }
+
+    trait :inactive do
+      status { 'inactive' }
+    end
+
+    trait :active do
+      status { 'active' }
+    end
+
+    trait :with_seller do
+      seller { create(:seller) }
+    end
+
+    factory :store_with_seller, traits: %i[with_seller]
+    factory :inactive_store, traits: %i[inactive]
+    factory :active_store, traits: %i[active]
+  end
+end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Store, type: :model do # rubocop:disable Metrics/BlockLength
+  describe 'validations' do # rubocop:disable Metrics/BlockLength
+    context 'when exists invalid attributes' do # rubocop:disable Metrics/BlockLength
+      context 'when status is not present' do
+        it 'is invalid' do
+          store = build(:store, status: nil)
+          store.valid?
+
+          expect(store.errors.first.attribute).to eq(:status)
+        end
+      end
+
+      context 'when phone_number is not in the correct format' do
+        it 'is invalid' do
+          store = build(:store, phone_number: '123')
+          store.valid?
+
+          expect(store.errors.first.attribute).to eq(:phone_number)
+        end
+      end
+
+      context 'when email is not in the correct format' do
+        it 'is invalid' do
+          store = build(:store, email: 'teste')
+          store.valid?
+
+          expect(store.errors.first.attribute).to eq(:email)
+        end
+      end
+
+      context 'when seller is not present' do
+        it 'is invalid' do
+          store = build(:store, seller: nil)
+          store.valid?
+
+          expect(store.errors.first.attribute).to eq(:seller)
+        end
+      end
+    end
+
+    context 'when all attributes are valid' do
+      it 'is valid' do
+        store = build(:store, email: 'teste@store.com', phone_number: '(11) 94002-8922', status: 'active', seller: create(:seller))
+        store.valid?
+
+        expect(store.errors).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -14,6 +14,15 @@ RSpec.describe Store, type: :model do # rubocop:disable Metrics/BlockLength
         end
       end
 
+      context 'when status is not included in the list' do
+        it 'is invalid' do
+          store = build(:store, status: 'whatever')
+          store.valid?
+
+          expect(store.errors.first.attribute).to eq(:status)
+        end
+      end
+
       context 'when phone_number is not in the correct format' do
         it 'is invalid' do
           store = build(:store, phone_number: '123')
@@ -44,7 +53,7 @@ RSpec.describe Store, type: :model do # rubocop:disable Metrics/BlockLength
 
     context 'when all attributes are valid' do
       it 'is valid' do
-        store = build(:store, email: 'teste@store.com', phone_number: '(11) 94002-8922', status: 'active', seller: create(:seller))
+        store = build(:store, email: 'teste@store.com', phone_number: '(11) 94002-8922', status: STORE::STATUS.first, seller: create(:seller))
         store.valid?
 
         expect(store.errors).to be_empty


### PR DESCRIPTION
Este PR adiciona a primeira versão do model Store, com seus devidos testes.
Também foi adicionado as traduções para os atributos de Store, com suas traduções de validação.


Imagem do diagrama do model Store
![image](https://github.com/EmanuelFacundo/yu_monolith/assets/38675971/3e81b41f-1948-4ba5-86cf-2206b20e3c1a)

obs: O id para endereço ainda não foi adicionado porque a tabela ainda não existe, como só irei criá-la posteriormente, optei por só adicionar este id após adicionar a tabela de endereços.
